### PR TITLE
Remove `resources :recipes` from routes.rb file

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
   resources :posts
-  resources :recipes
 end


### PR DESCRIPTION
Since this lesson only deals with posts, categories, and post_categories, it's not necessary to have routes for recipes.